### PR TITLE
PLAT-66:CRUD-articles.post-put-delete-getById

### DIFF
--- a/pages/api/articles/delete/[id].ts
+++ b/pages/api/articles/delete/[id].ts
@@ -1,0 +1,43 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "../../../../prismaClient/db"
+import { getSession, withApiAuthRequired } from '@auth0/nextjs-auth0';
+
+export default withApiAuthRequired(async function(req:NextApiRequest, res:NextApiResponse) {
+    const {method} = req
+    const blogId = Number(req.query.id)
+    const sessionUser = await getSession(req, res);
+
+    if (method == "DELETE"){
+
+        try{
+            const article = await prisma.articles.findUnique({
+                where: {id : blogId},
+                include: {
+                    user: true
+                }
+            })
+            
+            if (article.user.email === sessionUser.user.email) {
+                await prisma.articles.delete({
+                    where: {id: blogId}
+                })
+            } else {
+                res.status(401).json("USER_UNAUTHORIZED")
+            }
+            
+            const resObj = {
+                message: 'ARTICLE_DELETED_SUCCESSFULLY',
+                article: article
+              };
+
+           res.status(200).json(resObj)
+        }
+        catch(err){
+            console.error(err)
+            res.json(err)}
+    }
+    else {
+        res.status(405).json("METHOD_NOT_ALLOWED")
+    }
+ }
+)

--- a/pages/api/articles/getById/[id].ts
+++ b/pages/api/articles/getById/[id].ts
@@ -1,0 +1,45 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "../../../../prismaClient/db";
+
+export default async function(req: NextApiRequest, res: NextApiResponse) {
+    
+    const {method} = req
+    const blogId = Number(req.query.id)
+
+    if(method === "GET"){
+        try {
+            const getBlog = await prisma.articles.findUnique({
+                where:{id: blogId},
+                include:{
+                    user: {
+                        select: {
+                            username: true,
+                            email: true,
+                            userSettings: {
+                                select: {
+                                    description: true,
+                                    avatar: true
+                                }
+                            },
+                            articles:{
+                                select: {
+                                    title: true,
+                                    image: true
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            
+            res.status(200).json(getBlog)
+            
+        } catch (error) {
+             console.error(error)
+             res.status(404).json("RESOURCE_NOT_FOUND")    
+        }
+    } else {
+        res.status(405).json("METHOD_NOT_ALLOWED")
+    }
+
+}

--- a/pages/api/articles/post.ts
+++ b/pages/api/articles/post.ts
@@ -1,0 +1,46 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "../../../prismaClient/db";
+import findOrCreate from "../hashtags/findOrCreate"
+
+export default async function(req:NextApiRequest, res:NextApiResponse) { 
+    
+    const {method} = req
+    const {title, content, image, userId, hashtags} = req.body
+
+    if (method == "POST") {
+        
+        try{
+
+            const hashtagsIds = (await findOrCreate(hashtags)).map((el) => ({id: el.id}));
+
+            
+            const article = await prisma.articles.create({
+                data: {
+                    title: title,
+                    content: content,
+                    image: image,
+                    userId: userId,
+                    hashtags: {
+                        connect: hashtagsIds
+                    }
+                },
+                include: {
+                    hashtags: true
+                }
+            })
+            
+
+            const resObj = {
+                message: "ARTICLE_CREATED_SUCCESFULLY",
+                article: article
+            }
+
+         res.status(200).json(resObj);
+           
+        }catch(err){
+            res.status(500).json(`ERROR_CREATING_ARTICLE: ${err}`)
+        }}
+        else{
+            res.status(405).json("METHOD_NOT_ALLOWED")
+        }
+    }

--- a/pages/api/articles/put/[id].ts
+++ b/pages/api/articles/put/[id].ts
@@ -1,0 +1,63 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "../../../../prismaClient/db"
+import { getSession, withApiAuthRequired } from '@auth0/nextjs-auth0';
+import findOrCreate from "../../hashtags/findOrCreate"
+
+
+export default withApiAuthRequired(async function(req:NextApiRequest, res:NextApiResponse) {
+    const {method} = req
+    const blogId = Number(req.query.id)
+    const {title, content, image, userId, hashtags} = req.body
+    const sessionUser = await getSession(req, res);
+
+
+    if (method == "GET"){
+
+        try{
+            const article = await prisma.articles.findUnique({
+                where: {id : blogId},
+                include: {
+                    user: true
+                }
+            })
+
+            if (article.user.email == sessionUser.user.email) {
+                
+                const hashtagsIds = (await findOrCreate(hashtags)).map((el) => ({id: el.id}));
+
+                const updateArticle = await prisma.articles.update({
+                    where: {id: blogId},
+                    data: {
+                        title: title,
+                        content: content,
+                        image: image,
+                        userId: userId,
+                        hashtags: {
+                            set: hashtagsIds //set sobrescribe, la lista actualizada final de tags debe venir por body.
+                        }
+                    },
+                    include: {
+                        hashtags: true
+                    }
+                })
+
+                const resObj = {
+                    message: 'ARTICLE_UPDATED_SUCCESSFULLY',
+                    article: updateArticle
+                  };
+    
+               res.status(200).json(resObj)
+
+            } else {
+                res.status(401).json("USER_UNAUTHORIZED")
+            }
+        }
+        catch(err){
+            console.error(err)
+            res.json(err)}
+    }
+    else {
+        res.status(405).json("METHOD_NOT_ALLOWED")
+    }
+ }
+)

--- a/pages/api/hashtags/findOrCreate.ts
+++ b/pages/api/hashtags/findOrCreate.ts
@@ -1,0 +1,33 @@
+import { prisma } from "../../../prismaClient/db"
+async function findOrCreate(hashtags: string[]){
+    
+    try{
+
+        const hashtagsOnDB = await Promise.all(hashtags.map(async (tag: string) => {
+
+            tag = tag.toLowerCase()
+
+            const existingHashtag = await prisma.hashtags.findFirst({
+                where: { name: tag },
+            });
+            
+            if (existingHashtag === null || existingHashtag === undefined) {
+                const newHashtag = await prisma.hashtags.create({
+                    data: {
+                        name: tag,
+                    },
+                });
+                return newHashtag
+            } else {
+                return existingHashtag
+            }
+        }));
+
+        return hashtagsOnDB
+    
+    } catch(err){
+        console.error(err)
+    }
+}
+
+export default findOrCreate;


### PR DESCRIPTION
Agrega:
- Endpoint para nuevo articulo: /api/articles/post -- recibe por body, title, content, image, userId, hashtags (string[]).
- Endpoint para eliminar articulo: /api/articles/delete/[id] -- recibe nro. id del blog.
- Enpoint para editar articulo: /api/articles/put/[id] -- recibe nro. id del blog, por body lo que se quiera actualizar del art.
- Endpoint para obtener blog por ID: /api/articles/getById/[id] -- recibe nro. id del blog.
-Funcion "findOrCreate" para hashtags: recibe array con hashtags, los busca en la DB y devuelve, si no existen los crea y devuelve. (no es endpoint). 