### PR TITLE
Plat 56-obtener todos los articulos paginados

### DIFF
--- a/pages/api/articles/[page].ts
+++ b/pages/api/articles/[page].ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "../../../prismaClient/db"
 
+//endpoint para obtener todos los articulos pero paginados.
 //e.g: /api/blog/<num_de_pagina>
 export default async (req: NextApiRequest, res: NextApiResponse)=> {
     const {page} = req.query   

--- a/pages/api/blogs/[page].ts
+++ b/pages/api/blogs/[page].ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "../../../prismaClient/db"
+
+//e.g: /api/blog/<num_de_pagina>
+export default async (req: NextApiRequest, res: NextApiResponse)=> {
+    const {page} = req.query   
+    const {method} = req
+    const itemsPerPage = 20        
+    const pageNumber: number = Number(page) || 1;
+
+    if (method === "GET") {
+        try{
+
+            const allBlogs = await prisma.articles.findMany({
+                skip: (pageNumber -1) * itemsPerPage,
+                take: itemsPerPage
+            }
+            );
+
+            res.status(200).json({result: allBlogs, itemsPerPage: itemsPerPage, page: page});
+        } 
+        catch (err){res.status(404).json({message:"ERROR_FINDING_BLOGS", err})};
+    } else {
+        res.status(405).json({message:"METHOD_NOT_ALLOWED"});
+    }
+}


### PR DESCRIPTION
-agrega endpoint GET para obtener los blogs/articles paginados de 20.
-para modificar la cantidad a recibir solo modificar la variable "itemsPerPage"
-corrige el directorio del pull request anterior(eliminado): api/blogs/[page].ts ---> api/articles/[page.ts]