### PR TITLE
PLAT-75-blog-views:getById-schema.prisma

### DIFF
--- a/pages/api/articles/getById/[id].ts
+++ b/pages/api/articles/getById/[id].ts
@@ -5,9 +5,19 @@ export default async function(req: NextApiRequest, res: NextApiResponse) {
     
     const {method} = req
     const blogId = Number(req.query.id)
-
+    
     if(method === "GET"){
         try {
+
+            await prisma.articles.update({
+                where:{id: blogId},
+                data:{
+                    views: {
+                        increment: 1
+                    }
+                }
+            })
+
             const getBlog = await prisma.articles.findUnique({
                 where:{id: blogId},
                 include:{
@@ -23,6 +33,7 @@ export default async function(req: NextApiRequest, res: NextApiResponse) {
                             },
                             articles:{
                                 select: {
+                                    id: true,
                                     title: true,
                                     image: true
                                 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,7 @@ model Articles {
   title String
   content String
   image String
+  views Int @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
1. Agrega un campo "views" al esquema de artículos, que inicia como default en cero.
2. Antes de devolver un artículo (by Id), actualiza las views en uno con la query "increment", asi el blog llega al front ya con las visitas actualizadas desde el primer get.

extra: agregue el campo id a "articulos del mismo autor", para la descripcion del autor.