### PR TITLE
PLAT-75:missing-line-include-hashtags

### DIFF
--- a/pages/api/articles/getById/[id].ts
+++ b/pages/api/articles/getById/[id].ts
@@ -21,6 +21,7 @@ export default async function(req: NextApiRequest, res: NextApiResponse) {
             const getBlog = await prisma.articles.findUnique({
                 where:{id: blogId},
                 include:{
+                    hashtags: true,
                     user: {
                         select: {
                             username: true,


### PR DESCRIPTION
- El endpoint "getById" de "Articles", no traia los hashtags relacionados.
- Agrega linea 24.