### PR TITLE
PLAT-77-blogs-paginados-filtrados

### DIFF
--- a/pages/api/articles/[page].ts
+++ b/pages/api/articles/[page].ts
@@ -1,24 +1,65 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { prisma } from "../../../prismaClient/db"
+import { prisma } from "../../../prismaClient/db";
+import  blogsSort  from "../hashtags/blogsSort"
 
 //endpoint para obtener todos los articulos pero paginados.
 //e.g: /api/blog/<num_de_pagina>
+//--
+//body opcional para filtrar por hashtags,
+//{hashtags: <un unico string de hashtags separado por coma>} 
+//e.g: {hashtags: "javascript, typescript, css”}
+
 export default async (req: NextApiRequest, res: NextApiResponse)=> {
     const {page} = req.query   
     const {method} = req
     const itemsPerPage = 20        
     const pageNumber: number = Number(page) || 1;
+    const {hashtags} = req.body
 
     if (method === "GET") {
-        try{
+        try{    
+            if (hashtags) {
+                //caso con query de hashtags
 
-            const allBlogs = await prisma.articles.findMany({
-                skip: (pageNumber -1) * itemsPerPage,
-                take: itemsPerPage
+                const tagsSplit = hashtags.split(",")        //separamos por coma
+                const tagsArray = tagsSplit.map(tag => tag.trim())//borramos espacios
+
+
+                const allBlogs = await prisma.articles.findMany({   
+                    where:{
+                        hashtags: {
+                            some: {     
+                                name:{
+                                    in: tagsArray
+                                    //"buscar todos los hashtags donde todos o algunos coincidan con los de esta lista o array"
+                                }
+                            }
+                        },
+                    },
+                    include: {
+                        hashtags: true
+                    },
+                    skip: (pageNumber -1) * itemsPerPage,
+                    take: itemsPerPage
+                }
+                );
+    
+                //sort:
+                const orderedBlogs = blogsSort(hashtags, allBlogs);
+
+                res.status(200).json({result: orderedBlogs, itemsPerPage: itemsPerPage, page: page, filteredBy: tagsArray});
+            } else {
+                //caso sin query de hashtags
+                const allBlogs = await prisma.articles.findMany({
+                    include: {hashtags: true},
+                    skip: (pageNumber -1) * itemsPerPage,
+                    take: itemsPerPage
+                }
+                );
+    
+                res.status(200).json({result: allBlogs, itemsPerPage, page});
             }
-            );
 
-            res.status(200).json({result: allBlogs, itemsPerPage: itemsPerPage, page: page});
         } 
         catch (err){res.status(404).json({message:"ERROR_FINDING_BLOGS", err})};
     } else {

--- a/pages/api/articles/related/[id].ts
+++ b/pages/api/articles/related/[id].ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../../../prismaClient/db";
 import { NextApiRequest, NextApiResponse } from "next";
+import blogsSort from "../../hashtags/blogsSort";
 
 
 /**
@@ -50,7 +51,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
                 }
             })
 
-            res.status(200).json({blogId, hashtagsNames, relatedPosts})
+            //sort
+            const orderedBlogs = blogsSort(hashtagsNames, relatedPosts)
+
+            res.status(200).json({blogId, hashtags: hashtagsNames ,relatedBlogs: orderedBlogs})
         }
         catch(e){
             console.log(e)

--- a/pages/api/hashtags/blogsSort.ts
+++ b/pages/api/hashtags/blogsSort.ts
@@ -1,0 +1,28 @@
+//recibe: un array con hashtags(strings), y una lista de blogs(array de objetos) que incluyan estos hashtags,
+//devuelve: la lista de blogs ordenada de mayor a menor, basandose en cantidad de coincidencias
+//entre los hashtags de cada blog y la lista de hashtags.
+
+export default function blogsSort(hashtags: string[], blogs: any){
+
+    const hashtagMatches = {};
+
+    for(const blog of blogs){
+
+        const names = blog.hashtags.map(tag => tag.name); //obtenemos los hashtags del blog
+
+        const matches = names.filter(tag => hashtags.includes(tag)).length; //obtenemos la cantidad de matcheos entre tags
+        
+        hashtagMatches[blog.id] = matches; //guardamos como key: id del blog, value: cantidad de matcheos
+    }
+
+    blogs.sort((a,b) => {
+        const tagA = hashtagMatches[a.id];//para el sort, le damos a cada id de los blogs a comparar, el valor de la cantidad de matcheos.
+        const tagB = hashtagMatches[b.id];
+
+        return tagB - tagA
+
+    })
+
+    return blogs;
+
+}


### PR DESCRIPTION
- Agrega la posibilidad de filtrar por hashtags en el endpoint que devuelve los blogs paginados
- Agrega una función sort, para ordenar los blogs por coincidencia de hashtags, de mayor a menor. (Prisma los devuelve en un orden genérico según los encuentra).
- Extra: la función sort tambien arregla el mismo problema en el endpoint que busca los blogs relacionados a un blog.